### PR TITLE
feat: add route for manual Facebook API calls

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,6 +89,7 @@ def create_app():
     from routes.auth import auth_bp
     from routes.stack_post import stack_post_bp
     from routes.ads_manager import ads_manager_bp
+    from routes.api_calls import api_calls_bp
 
     app.register_blueprint(home_bp)
     app.register_blueprint(facebook_bp)
@@ -96,6 +97,7 @@ def create_app():
     app.register_blueprint(auth_bp)
     app.register_blueprint(stack_post_bp)
     app.register_blueprint(ads_manager_bp)
+    app.register_blueprint(api_calls_bp)
 
     # ===== Auth guard =====
     @app.before_request

--- a/routes/api_calls.py
+++ b/routes/api_calls.py
@@ -1,0 +1,112 @@
+from flask import Blueprint, render_template, session, flash, redirect, url_for
+from models.facebook_account import FacebookAccount
+from models.facebook_ad_account import FacebookAdAccount
+from models.page import Page
+import requests
+import logging
+
+api_calls_bp = Blueprint("api_calls", __name__)
+
+
+@api_calls_bp.route("/api_calls", methods=["GET"])
+def api_calls_home():
+    """Render page with buttons to trigger various Facebook API calls."""
+    if "facebook_user_id" not in session:
+        flash("You need to log in to access this page.", "danger")
+        return redirect(url_for("auth.login"))
+
+    facebook_account_id = session["facebook_user_id"]
+    pages = Page.query.filter_by(facebook_account_id=facebook_account_id).all()
+    ad_accounts = FacebookAdAccount.query.filter_by(
+        facebook_account_id=facebook_account_id
+    ).all()
+    return render_template("api_calls.html", pages=pages, ad_accounts=ad_accounts)
+
+
+def _check_rate_limit(response):
+    if response.status_code == 429:
+        flash("Facebook API rate limit reached. Please pause and try again later.", "danger")
+        return True
+    return False
+
+
+def _get_access_token():
+    facebook_account_id = session.get("facebook_user_id")
+    account = FacebookAccount.query.filter_by(id=facebook_account_id).first()
+    if not account:
+        flash("Facebook account not found.", "danger")
+        return None
+    return account.access_token
+
+
+@api_calls_bp.route("/api_calls/trigger/<string:action>", methods=["POST"])
+def trigger_api_call(action: str):
+    """Trigger specific Facebook API call and report rate limit status."""
+    if "facebook_user_id" not in session:
+        flash("You need to log in to access this page.", "danger")
+        return redirect(url_for("auth.login"))
+
+    token = _get_access_token()
+    if not token:
+        return redirect(url_for("api_calls.api_calls_home"))
+
+    try:
+        response = None
+        fb_api = "https://graph.facebook.com/v21.0"
+        if action == "account_fb":
+            response = requests.get(f"{fb_api}/me", params={"access_token": token})
+        elif action == "get_pages":
+            response = requests.get(
+                f"{fb_api}/me/accounts", params={"access_token": token}
+            )
+        elif action == "list_posts":
+            pages = Page.query.filter_by(
+                facebook_account_id=session["facebook_user_id"]
+            ).all()
+            for page in pages:
+                response = requests.get(
+                    f"{fb_api}/{page.page_id}/posts",
+                    params={"access_token": page.access_token},
+                )
+                if _check_rate_limit(response):
+                    return redirect(url_for("api_calls.api_calls_home"))
+        elif action == "list_ad_accounts":
+            response = requests.get(
+                f"{fb_api}/me/adaccounts", params={"access_token": token}
+            )
+        elif action in {"fetch_facebook_campaigns", "list_fb_campaigns"}:
+            ad = FacebookAdAccount.query.filter_by(
+                facebook_account_id=session["facebook_user_id"]
+            ).first()
+            if ad:
+                response = requests.get(
+                    f"{fb_api}/{ad.facebook_ad_account_id}/campaigns",
+                    params={"access_token": token},
+                )
+            else:
+                flash("No ad account found for campaigns.", "warning")
+        elif action in {"view_ads", "get_account_ads"}:
+            ad = FacebookAdAccount.query.filter_by(
+                facebook_account_id=session["facebook_user_id"]
+            ).first()
+            if ad:
+                response = requests.get(
+                    f"{fb_api}/{ad.facebook_ad_account_id}/ads",
+                    params={"access_token": token},
+                )
+            else:
+                flash("No ad account found for ads.", "warning")
+        else:
+            flash("Unknown action.", "danger")
+            return redirect(url_for("api_calls.api_calls_home"))
+
+        if response and _check_rate_limit(response):
+            return redirect(url_for("api_calls.api_calls_home"))
+        if response is not None and response.ok:
+            flash(f"Called {action} API successfully.", "success")
+        elif response is not None:
+            flash(f"API call failed: {response.text}", "danger")
+    except requests.RequestException as exc:
+        logging.exception("Error calling Facebook API")
+        flash(f"Error calling API: {exc}", "danger")
+    return redirect(url_for("api_calls.api_calls_home"))

--- a/templates/api_calls.html
+++ b/templates/api_calls.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container mt-4">
+  <h2>Facebook API Call Helper</h2>
+  <p>Use the buttons below to call Facebook APIs. Stop if you see a rate limit warning.</p>
+
+  <div class="row g-2">
+    <div class="col-md-3">
+      <form method="post" action="{{ url_for('api_calls.trigger_api_call', action='account_fb') }}">
+        <button class="btn btn-primary w-100" type="submit">Account Info</button>
+      </form>
+    </div>
+    <div class="col-md-3">
+      <form method="post" action="{{ url_for('api_calls.trigger_api_call', action='get_pages') }}">
+        <button class="btn btn-primary w-100" type="submit">Get Pages</button>
+      </form>
+    </div>
+    <div class="col-md-3">
+      <form method="post" action="{{ url_for('api_calls.trigger_api_call', action='list_posts') }}">
+        <button class="btn btn-primary w-100" type="submit">List Posts</button>
+      </form>
+    </div>
+    <div class="col-md-3">
+      <form method="post" action="{{ url_for('api_calls.trigger_api_call', action='list_ad_accounts') }}">
+        <button class="btn btn-primary w-100" type="submit">List Ad Accounts</button>
+      </form>
+    </div>
+  </div>
+
+  <div class="row g-2 mt-2">
+    <div class="col-md-3">
+      <form method="post" action="{{ url_for('api_calls.trigger_api_call', action='fetch_facebook_campaigns') }}">
+        <button class="btn btn-secondary w-100" type="submit">Fetch Campaigns</button>
+      </form>
+    </div>
+    <div class="col-md-3">
+      <form method="post" action="{{ url_for('api_calls.trigger_api_call', action='view_ads') }}">
+        <button class="btn btn-secondary w-100" type="submit">View Ads</button>
+      </form>
+    </div>
+    <div class="col-md-3">
+      <form method="post" action="{{ url_for('api_calls.trigger_api_call', action='list_fb_campaigns') }}">
+        <button class="btn btn-secondary w-100" type="submit">List Campaigns</button>
+      </form>
+    </div>
+    <div class="col-md-3">
+      <form method="post" action="{{ url_for('api_calls.trigger_api_call', action='get_account_ads') }}">
+        <button class="btn btn-secondary w-100" type="submit">Get Account Ads</button>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `api_calls` blueprint to help users manually trigger Facebook API endpoints
- provide helper page with buttons to call multiple endpoints and detect rate limiting
- wire new blueprint into application

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d45f770848325b49bbaccf4f0c99d